### PR TITLE
fix(examples): repair exascale paths and site coordinates loading

### DIFF
--- a/config/examples/exascale/app.yaml
+++ b/config/examples/exascale/app.yaml
@@ -2,9 +2,9 @@ app:
   name: Rackscope
   description: Datacenter Overview
 paths:
-  topology: config/examples/hpc-cluster/topology
-  templates: config/examples/hpc-cluster/templates
-  checks: config/examples/hpc-cluster/checks/library
+  topology: topology
+  templates: templates
+  checks: checks/library
   metrics: config/metrics/library
 refresh:
   room_state_seconds: 30

--- a/config/examples/exascale/topology/sites.yaml
+++ b/config/examples/exascale/topology/sites.yaml
@@ -1,16 +1,22 @@
 sites:
 - id: site-paris
   name: Paris — Site Principal
-  lat: 48.8566
-  lon: 2.3522
+  location:
+    lat: 48.8566
+    lon: 2.3522
+    address: Paris, FR
   rooms_path: datacenters/site-paris/rooms
 - id: site-toulouse
   name: Toulouse — Site Secondaire
-  lat: 43.6047
-  lon: 1.4442
+  location:
+    lat: 43.6047
+    lon: 1.4442
+    address: Toulouse, FR
   rooms_path: datacenters/site-toulouse/rooms
 - id: site-berlin
   name: Berlin — DR Site
-  lat: 52.52
-  lon: 13.405
+  location:
+    lat: 52.52
+    lon: 13.405
+    address: Berlin, DE
   rooms_path: datacenters/site-berlin/rooms

--- a/config/examples/hpc-cluster/topology/sites.yaml
+++ b/config/examples/hpc-cluster/topology/sites.yaml
@@ -1,6 +1,8 @@
 sites:
 - id: dc-paris
   name: Paris HPC Datacenter
-  lat: 48.8566
-  lon: 2.3522
+  location:
+    lat: 48.8566
+    lon: 2.3522
+    address: Paris, FR
   rooms_path: datacenters/dc-paris/rooms

--- a/config/examples/small-cluster/topology/sites.yaml
+++ b/config/examples/small-cluster/topology/sites.yaml
@@ -2,6 +2,8 @@ sites:
 - id: dc-main
   name: Main Datacenter
   description: Small HPC cluster
-  lat: 48.8566
-  lon: 2.3522
+  location:
+    lat: 48.8566
+    lon: 2.3522
+    address: Paris, FR
   rooms_path: datacenters/dc-main/rooms


### PR DESCRIPTION
## Summary

- **Fix exascale example paths** — `config/examples/exascale/app.yaml` hardcoded paths pointing at `hpc-cluster`, so `make use-exascale` silently loaded the single-site hpc-cluster topology instead of the intended 3-site exascale layout. Switched to relative paths, matching the pattern used by `hpc-cluster`, `small-cluster`, and `bull`.
- **Fix site coordinates loading** — the `Site` model expects a nested `location: { lat, lon, address }` object, but `exascale`, `hpc-cluster`, and `small-cluster` declared flat `lat:` / `lon:` keys at the site root. The loader (`src/rackscope/model/loader.py:191`) reads `site.get("location")` only, so flat keys were silently ignored and produced `location: null` in `/api/sites` responses. Migrated the three affected examples to the nested form. `bull` was already correct and is the reference. `homelab` has no coordinates by design and is unchanged.

## Why this matters

These are two latent bugs in the shipped examples that surface as user-visible regressions:

- `make use-exascale` did not actually load exascale (wrong site count, wrong topology, wrong scale)
- World Map / site coordinates feature appeared broken on most bundled examples

Both bugs date back to `c441bec feat: v1.0.0-beta1 — Initial Release`.

No code changes — config examples only. No breaking changes for any user profile (`config/profiles/` is empty in this repo).

## Test plan

- [x] `make use-exascale` → backend loads 3 sites (Paris / Toulouse / Berlin), each with coordinates
- [x] `make use-hpc-cluster` → site `dc-paris` exposes coordinates via `/api/sites`
- [x] `make use-small-cluster` → site `dc-main` exposes coordinates via `/api/sites`
- [x] `make use-bull` → unchanged, still correct (regression check on the reference example)
- [x] `make use-homelab` → unchanged, no coordinates (intentional)
- [ ] CI passes (yamllint + tests)

## Related

Follow-ups tracked separately:

- #22 — self-host Swagger UI and ReDoc assets to remove CDN dependency
- #23 — audit all external runtime dependencies for fully offline deployments