### PR TITLE
chore(deps): migrate to lucide-react 1.x

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "js-yaml": "^4.2.0",
         "leaflet": "^1.9.4",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.17.0",
         "monaco-editor": "^0.55.1",
         "react": "^19.2.7",
         "react-apexcharts": "^2.1.0",
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "clsx": "^2.1.1",
     "js-yaml": "^4.2.0",
     "leaflet": "^1.9.4",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.17.0",
     "monaco-editor": "^0.55.1",
     "react": "^19.2.7",
     "react-apexcharts": "^2.1.0",

--- a/frontend/src/app/components/icons/BrandIcons.tsx
+++ b/frontend/src/app/components/icons/BrandIcons.tsx
@@ -1,0 +1,27 @@
+/**
+ * BrandIcons — local SVG components for third-party brand logos.
+ *
+ * lucide-react 1.x removed all brand/logo icons (GitHub, Twitter/X, …).
+ * These small inline components replace them with no extra dependency,
+ * matching the lucide API surface we rely on: a `className`-accepting
+ * component usable both as JSX (`<GithubIcon className="h-4 w-4" />`) and
+ * as a component reference (`icon={GithubIcon}`).
+ *
+ * Paths from simple-icons (CC0), 24×24 viewBox, fill="currentColor".
+ */
+
+type BrandIconProps = {
+  className?: string;
+};
+
+export const GithubIcon = ({ className }: BrandIconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+);
+
+export const XIcon = ({ className }: BrandIconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+  </svg>
+);

--- a/frontend/src/app/pages/AboutPage.tsx
+++ b/frontend/src/app/pages/AboutPage.tsx
@@ -1,15 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import {
-  Github,
-  BookOpen,
-  ExternalLink,
-  Code2,
-  RefreshCw,
-  X,
-  Heart,
-  Coffee,
-  Bot,
-} from 'lucide-react';
+import { BookOpen, ExternalLink, Code2, RefreshCw, X, Heart, Coffee, Bot } from 'lucide-react';
+import { GithubIcon } from '@app/components/icons/BrandIcons';
 import { usePageTitle } from '../contexts/PageTitleContext';
 import { PageHeader, PageBreadcrumb, SectionCard } from './templates/EmptyPage';
 import { AppIcon, getIconContainerClass, getIconSize } from '../components/AppIcon';
@@ -633,7 +624,7 @@ const DeveloperCardModal = ({ onClose }: { onClose: () => void }) => {
               rel="noopener noreferrer"
               className="text-brand-500 flex items-center gap-1.5 text-sm hover:underline"
             >
-              <Github className="h-4 w-4" />
+              <GithubIcon className="h-4 w-4" />
               github.com/SckyzO
             </a>
             <button
@@ -861,7 +852,7 @@ export const AboutPage = () => {
         <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
           <SectionCard title="Links" desc="Source code and documentation">
             <div className="space-y-2">
-              <ExtLink href="https://github.com/SckyzO/rackscope" icon={Github}>
+              <ExtLink href="https://github.com/SckyzO/rackscope" icon={GithubIcon}>
                 GitHub — SckyzO/rackscope
               </ExtLink>
               <ExtLink href="https://www.rackscope.dev" icon={BookOpen}>
@@ -904,7 +895,7 @@ export const AboutPage = () => {
                   rel="noopener noreferrer"
                   className="text-brand-500 mt-1 flex items-center gap-1 text-xs hover:underline"
                 >
-                  <Github className="h-3 w-3" />
+                  <GithubIcon className="h-3 w-3" />
                   github.com/SckyzO
                 </a>
               </div>

--- a/frontend/src/app/pages/ui/PopoversPage.tsx
+++ b/frontend/src/app/pages/ui/PopoversPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { MapPin, Link as LinkIcon, Twitter, Github } from 'lucide-react';
+import { MapPin, Link as LinkIcon } from 'lucide-react';
+import { GithubIcon, XIcon } from '@app/components/icons/BrandIcons';
 import { usePageTitle } from '@app/contexts/PageTitleContext';
 import { PageHeader, PageBreadcrumb, SectionCard } from '../templates/EmptyPage';
 
@@ -56,13 +57,13 @@ const PopoverContent = () => (
           href="#"
           className="hover:text-brand-500 flex h-7 w-7 items-center justify-center rounded-lg border border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400"
         >
-          <Twitter className="h-3.5 w-3.5" />
+          <XIcon className="h-3.5 w-3.5" />
         </a>
         <a
           href="#"
           className="hover:text-brand-500 flex h-7 w-7 items-center justify-center rounded-lg border border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400"
         >
-          <Github className="h-3.5 w-3.5" />
+          <GithubIcon className="h-3.5 w-3.5" />
         </a>
       </div>
     </div>


### PR DESCRIPTION
Part of ISSUE_P (tier 2 of 3). lucide-react 1.x **removed all brand/logo icons**. We used two of them (`Github`, `Twitter`).

## Change

Replaced with local inline SVG components — **no new dependency** added (a brand-icon package would be heavyweight for two glyphs):

- **new** `frontend/src/app/components/icons/BrandIcons.tsx` — `GithubIcon` + `XIcon` (simple-icons CC0 paths, 24×24, `fill=currentColor`, `className`-compatible so they drop into both JSX usage and the `icon={...}` component-reference prop).
- `AboutPage.tsx` — `Github` → `GithubIcon` (3 sites, incl. `ExtLink icon={...}`).
- `PopoversPage.tsx` (UI showcase/demo) — `Twitter` → `XIcon`, `Github` → `GithubIcon`.
- `lucide-react` `^0.577.0` → `^1.17.0`; lockfile regenerated.

Twitter is rendered as the current **X** logo (brand was renamed). Only affected a demo page.

## Validation

- frontend `npm run build` — OK (`tsc -b` confirms no missing icon exports across all 141 icons we import)
- `make lint` — 9 linters, 0 errors

## Note

peerDeps of lucide-react 1.17.0 (`react ^16.5.1 || 17 || 18 || 19`) are satisfied by React 19 — no peer conflict.